### PR TITLE
New ELBs to support secured networking

### DIFF
--- a/MDL-CHANGELOG.md
+++ b/MDL-CHANGELOG.md
@@ -1,0 +1,7 @@
+## 2017-06-07
+
+  * Creation of new `mdl_master` default branch, matching existing `master`
+  * Introduction of two new side-by-side ELBs to support VPN and CloudFront
+    access. Existing ELB to be removed subsequently
+  * Introduction of new `terraform-enterprise-instance` security group to
+    enable networking to/from the ELBs

--- a/MDL-UPGRADING.md
+++ b/MDL-UPGRADING.md
@@ -1,0 +1,32 @@
+This repository has been forked from `git@github.com:hashicorp/terraform-enterprise-modules.git`
+but has significant security changes. The default branch has been changed to
+`mdl_master` to reflect this.
+
+# Local setup
+
+```
+git clone git@github.com:MDL/terraform-enterprise-modules.git
+cd terraform-enterprise-modules
+git remote add hashicorp git@github.com:hashicorp/terraform-enterprise-modules.git
+# We should not implicate McK while using public GitHub:
+git config user.name {{PUBLIC NAME}}
+git config user.email {{PUBLIC EMAIL}}
+git fetch hashicorp
+git checkout mdl_master
+```
+
+# Upgrading from HashiCorp
+
+The following is a suggested process.
+
+```
+git fetch origin
+git fetch hashicorp
+git checkout mdl_master
+git merge --ff-only origin/mdl_master
+git checkout -b mdl_master_SAVEPOINT
+git rebase -i hashicorp/{{RELEASE branch or tag}}
+# Validate the Terraform changes that will occur and get the changes reviewed
+git push origin --force mdl_master
+git push origin mdl_master_SAVEPOINT:mdl_master_YYYYMMDD
+```

--- a/aws-standard/mdl_extensions.tf
+++ b/aws-standard/mdl_extensions.tf
@@ -1,0 +1,18 @@
+# AWS certificate IDs for the MDL CloudFront-facing ELB
+variable "cert_origin_id" {}
+
+# AWS certificate IDs for the MDL VPN-facing ELB
+variable "cert_internal_id" {}
+
+# CIDR range for VPN access to the instance
+variable "vpn_access_cidr" {}
+
+module "mdl_extensions" {
+  source = "../modules/mdl_extensions"
+
+  cert_origin_id   = "${var.cert_origin_id}"
+  cert_internal_id = "${var.cert_internal_id}"
+  vpc_id           = "${data.aws_subnet.instance.vpc_id}"
+  elb_subnet_id    = "${var.elb_subnet_id}"
+  vpn_access_cidr  = "${var.vpn_access_cidr}"
+}

--- a/modules/mdl_extensions/README.md
+++ b/modules/mdl_extensions/README.md
@@ -1,0 +1,7 @@
+# MDL extensions to the Hashicorp TF design
+
+1. Introduction of a private ELB to route traffic from MDL Cloud VPN
+2. Introduction of a public ELB
+3. Removal of HashiCorp public ELB to simplify coding
+4. CloudFront distribution for Firm PoPs created via `ops-cdn` repo
+

--- a/modules/mdl_extensions/outputs.tf
+++ b/modules/mdl_extensions/outputs.tf
@@ -1,0 +1,11 @@
+output "sg-terraform-instance-id" {
+  value = "${aws_security_group.terraform-enterprise-instance.id}"
+}
+
+output "elb-internal-id" {
+  value = "${aws_elb.portal-internal.id}"
+}
+
+output "elb-public-id" {
+  value = "${aws_elb.portal-public.id}"
+}

--- a/modules/mdl_extensions/portal-internal.tf
+++ b/modules/mdl_extensions/portal-internal.tf
@@ -1,0 +1,30 @@
+resource "aws_elb" "portal-internal" {
+  name     = "terraform-enterprise-internal"
+  internal = true
+
+  subnets = ["${var.elb_subnet_id}"]
+
+  listener {
+    lb_port            = 443
+    lb_protocol        = "https"
+    instance_port      = 8080
+    instance_protocol  = "http"
+    ssl_certificate_id = "${var.cert_internal_id}"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "TCP:8080"
+    interval            = 5
+  }
+
+  security_groups = ["${aws_security_group.portal-internal.id}"]
+
+  idle_timeout = 300
+
+  tags {
+    Name = "terraform-enterprise-internal"
+  }
+}

--- a/modules/mdl_extensions/portal-public.tf
+++ b/modules/mdl_extensions/portal-public.tf
@@ -1,0 +1,25 @@
+resource "aws_elb" "portal-public" {
+  name = "terraform-enterprise-public"
+
+  subnets = ["${var.elb_subnet_id}"]
+
+  listener {
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${var.cert_origin_id}"
+    instance_port      = 8080
+    instance_protocol  = "http"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    interval            = 30
+    target              = "TCP:81"
+  }
+
+  security_groups = ["${aws_security_group.portal-public.id}"]
+
+  idle_timeout = 300
+}

--- a/modules/mdl_extensions/security-portal-internal.tf
+++ b/modules/mdl_extensions/security-portal-internal.tf
@@ -1,0 +1,26 @@
+resource "aws_security_group" "portal-internal" {
+  name   = "terraform-portal-internal"
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name = "terraform-portal-internal"
+  }
+}
+
+resource "aws_security_group_rule" "portal-internal-from-vpn" {
+  security_group_id = "${aws_security_group.portal-internal.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.vpn_access_cidr}"]
+}
+
+resource "aws_security_group_rule" "portal-internal-to-tfe" {
+  security_group_id        = "${aws_security_group.portal-internal.id}"
+  type                     = "egress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.terraform-enterprise-instance.id}"
+}

--- a/modules/mdl_extensions/security-portal-public.tf
+++ b/modules/mdl_extensions/security-portal-public.tf
@@ -1,0 +1,31 @@
+resource "aws_security_group" "portal-public" {
+  name   = "terraform-portal-public"
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name = "terraform-portal-public"
+  }
+}
+
+data "aws_ip_ranges" "cloudfront" {
+  services = ["cloudfront"]
+  regions  = []
+}
+
+resource "aws_security_group_rule" "portal-public-from-cloudfront" {
+  security_group_id = "${aws_security_group.portal-public.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${data.aws_ip_ranges.cloudfront.cidr_blocks}"]
+}
+
+resource "aws_security_group_rule" "portal-public-to-tfe" {
+  security_group_id        = "${aws_security_group.portal-public.id}"
+  type                     = "egress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.terraform-enterprise-instance.id}"
+}

--- a/modules/mdl_extensions/security-terraform-enterprise-instance.tf
+++ b/modules/mdl_extensions/security-terraform-enterprise-instance.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group" "terraform-enterprise-instance" {
+  name   = "terraform-enterprise-instance"
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name = "terraform-enterprise-instance"
+  }
+}

--- a/modules/mdl_extensions/variables.tf
+++ b/modules/mdl_extensions/variables.tf
@@ -1,0 +1,9 @@
+variable "vpc_id" {}
+
+variable "cert_origin_id" {}
+
+variable "cert_internal_id" {}
+
+variable "elb_subnet_id" {}
+
+variable "vpn_access_cidr" {}


### PR DESCRIPTION
Part of delivering https://github.mdl.cloud/DevOps/devops.github.mdl.cloud/issues/1015.

This change introduces two new ELBs and leaves the existing infrastructure untouched.

Future updates will link the ELBs to the instance and add a CloudFront distribution.